### PR TITLE
Added Taint.cpp to CMake component list

### DIFF
--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -26,6 +26,7 @@ klee_add_component(kleeCore
   StatsTracker.cpp
   TimingSolver.cpp
   UserSearcher.cpp
+  Taint.cpp
 )
 
 # TODO: Work out what the correct LLVM components are for


### PR DESCRIPTION
Fixes the following build error: 

```
[ 83%] Linking CXX executable ../../bin/klee
../../lib/libkleeCore.a(Executor.cpp.o): In function `klee::Executor::bindModuleConstants()':
/home/daneid/packages/klee-taint/lib/Core/Executor.cpp:2708: undefined reference to `klee::EMPTYTAINTSET'
/home/daneid/packages/klee-taint/lib/Core/Memory.cpp:622: undefined reference to `klee::EMPTYTAINTSET'
../../lib/libkleeCore.a(Memory.cpp.o): In function `klee::ObjectState::readByteTaint(unsigned int) const':
/home/daneid/packages/klee-taint/lib/Core/Memory.cpp:632: undefined reference to `klee::EMPTYTAINTSET'
../../lib/libkleeCore.a(SpecialFunctionHandler.cpp.o): In function `klee::SpecialFunctionHandler::handleGetTaint(klee::ExecutionState&, klee::KInstruction*, std::vector<klee::ref<klee::Expr>, std::allocator<klee::ref<klee::Expr> > >&)':
/home/daneid/packages/klee-taint/lib/Core/SpecialFunctionHandler.cpp:815: undefined reference to `klee::EMPTYTAINTSET'
/home/daneid/packages/klee-taint/lib/Core/SpecialFunctionHandler.cpp:818: undefined reference to `klee::mergeTaint(unsigned int&, unsigned int)'
collect2: error: ld returned 1 exit status
make[2]: *** [tools/klee/CMakeFiles/klee.dir/build.make:140: bin/klee] Error 1
make[1]: *** [CMakeFiles/Makefile2:748: tools/klee/CMakeFiles/klee.dir/all] Error 2
make: *** [Makefile:130: all] Error 2

```